### PR TITLE
Fix return type for areaScoring

### DIFF
--- a/javascript/goscorer.js
+++ b/javascript/goscorer.js
@@ -197,7 +197,7 @@ function territoryScoring(
 /**
  * @param {color[][]} stones - BLACK or WHITE or EMPTY indicating the stones on the board.
  * @param {bool[][]} markedDead - true if the location has a stone marked as dead, and false otherwise.
- * @return {LocScore[][]}
+ * @return {color[][]}
  */
 function areaScoring(
     stones,


### PR DESCRIPTION
Fixes the documentation for `areaScoring` to note it returns a simple matrix of `color`, not the `LocScore` structure like `territoryScoring` does