### PR TITLE
Handle edge case for 1 row boards

### DIFF
--- a/javascript/goscorer.js
+++ b/javascript/goscorer.js
@@ -408,6 +408,9 @@ function markConnectionBlocks(
                                     continue;
 
                                 [ty, tx] = getTargetYX(pdy, pdx);
+                                if(!isOnBoard(ty, tx, ysize, xsize))
+                                    continue;
+
                                 if(c === 'p') {
                                     if(!(stones[ty][tx] === pla && !markedDead[ty][tx])) {
                                         mismatch = true;


### PR DESCRIPTION
`getTargetXY` returns `-1` for `ty` at some point while evaluating a 3x1 board, this check just handles those kinds of edge cases.